### PR TITLE
feat: sync views with URL paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { AppProvider, useApp } from './context/AppContext';
 import { useAuth } from './hooks/useAuth';
 import LoginForm from './components/Auth/LoginForm';
@@ -12,8 +12,30 @@ import RoleManagementView from './components/Users/RoleManagementView';
 import ProtectedRoute from './components/Auth/ProtectedRoute';
 
 function AppContent() {
-  const [activeView, setActiveView] = useState('dashboard');
+  const validViews = ['dashboard', 'incidents', 'users', 'roles', 'audit', 'settings'];
+
+  const getViewFromPath = () => {
+    const path = window.location.pathname.replace('/', '');
+    return validViews.includes(path) ? path : 'dashboard';
+  };
+
+  const [activeView, setActiveViewState] = useState(getViewFromPath);
   const { loading } = useApp();
+
+  useEffect(() => {
+    const handlePopState = () => setActiveViewState(getViewFromPath());
+    window.addEventListener('popstate', handlePopState);
+    const current = window.location.pathname.replace('/', '');
+    if (!validViews.includes(current)) {
+      window.history.replaceState(null, '', '/dashboard');
+    }
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  const setActiveView = (view: string) => {
+    setActiveViewState(view);
+    window.history.pushState(null, '', `/${view}`);
+  };
 
   if (loading) {
     return (

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -65,8 +65,12 @@ export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
             
             return (
               <li key={item.id}>
-                <button
-                  onClick={() => onViewChange(item.id)}
+                <a
+                  href={`/${item.id}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    onViewChange(item.id);
+                  }}
                   className={`w-full flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
                     isActive
                       ? 'bg-blue-600 text-white'
@@ -75,7 +79,7 @@ export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
                 >
                   <Icon className="w-5 h-5 mr-3" />
                   {item.label}
-                </button>
+                </a>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
- keep current view in sync with browser URL so dashboard, incidents, audit and other pages can be opened directly
- use anchor elements in the sidebar to update address bar when switching sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 13 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688eb3d666648328beb386f70e5843cd